### PR TITLE
Support Alt-/ key bind.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -205,6 +205,7 @@ var name2char = map[string]string{
 	K_ALT_X:         "\x1Bx",
 	K_ALT_Y:         "\x1By",
 	K_ALT_Z:         "\x1Bz",
+	K_ALT_OEM_2:     "\x1B/",
 	K_CLEAR:         "0x0C",
 	K_CTRL:          "0x11",
 	K_CTRL_BREAK:    "0x03",


### PR DESCRIPTION
I want nyagos to support "Alt-/" key combination.

Without this patch, `name2char` in constant.go does not include `K_ALT_OEM_2`, so "Alt-/" is not handled as key combination.