### PR TITLE
Fix: panic in `completion.PathComplete` when the last token is an empty string

### DIFF
--- a/completion/file.go
+++ b/completion/file.go
@@ -19,7 +19,10 @@ func PathComplete(field []string) (completionSet []string, listingSet []string) 
 	}
 	target := field[len(field)-1]
 	var dir, base string
-	if tail := target[len(target)-1]; tail == os.PathSeparator || tail == '/' {
+	if len(target) <= 0 {
+		base = ""
+		dir = ""
+	} else if tail := target[len(target)-1]; tail == os.PathSeparator || tail == '/' {
 		base = ""
 		dir = target
 	} else {

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,5 +1,7 @@
 ( **English** / [Japanese](release_note_ja.md) )
 
+- Fixed a panic in completion.PathComplete that occurred when the last token was an empty string. It now correctly returns all files in the current directory.
+
 v1.12.0
 =======
 Nov 1, 2025

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,5 +1,7 @@
 ( [English](release_note_en.md) / **Japanese** )
 
+- 補完候補のファイル名リストを生成する `completion.PathComplete` が、最後の単語が空文字列のときにパニックを起こす問題を修正し、カレントディレクトリ内の全ファイルを返すようにした。
+
 v1.12.0
 =======
 Nov 1, 2025


### PR DESCRIPTION
## Changes in this pull request (English)

- Fixed a panic in completion.PathComplete that occurred when the last token was an empty string. It now correctly returns all files in the current directory.

## Changes in this pull request (Japanese)

- 補完候補のファイル名リストを生成する `completion.PathComplete` が、最後の単語が空文字列のときにパニックを起こす問題を修正し、カレントディレクトリ内の全ファイルを返すようにした。