### PR TITLE
Fixed the warnings of Go Report Card

### DIFF
--- a/coloring/vimbatch.go
+++ b/coloring/vimbatch.go
@@ -37,8 +37,6 @@ func (s *VimBatch) Next(codepoint rune) readline.ColorSequence {
 		color = readline.Magenta
 	} else if codepoint == '&' {
 		color = readline.DarkYellow
-	} else {
-		color = readline.DefaultForeGroundColor
 	}
 	s.bits = newbits
 	return color

--- a/test/bench/slow.go
+++ b/test/bench/slow.go
@@ -24,7 +24,7 @@ func (SlowPattern) FindAllStringIndex(string, int) [][]int {
 
 func main() {
 	editor := &readline.Editor{
-		Writer:  colorable.NewColorableStdout(),
+		Writer: colorable.NewColorableStdout(),
 		Highlight: []readline.Highlight{
 			{Pattern: regexp.MustCompile("&"), Sequence: "\x1B[33;49;22m"},
 			{Pattern: regexp.MustCompile(`"[^"]*"`), Sequence: "\x1B[35;49;22m"},
@@ -32,9 +32,9 @@ func main() {
 			{Pattern: regexp.MustCompile("\u3000"), Sequence: "\x1B[37;41;22m"},
 			{Pattern: SlowPattern{}, Sequence: ""},
 		},
-		PredictColor:   [...]string{"\x1B[3;22;34m", "\x1B[23;39m"},
-		ResetColor:     "\x1B[0m",
-		DefaultColor:   "\x1B[33;49;1m",
+		PredictColor: [...]string{"\x1B[3;22;34m", "\x1B[23;39m"},
+		ResetColor:   "\x1B[0m",
+		DefaultColor: "\x1B[33;49;1m",
 	}
 	editor.BindKey(keys.CtrlI, completion.CmdCompletionOrList{
 		Completion: completion.File{},


### PR DESCRIPTION
-  Fix: `Go Report Card`: IneffAssign detects ineffectual assignments in Go code.
   coloring/vimbatch.go: Line 29: warning: ineffectual assignment to color (ineffassign)

- Fix: `Go Report Card`: Gofmt formats Go programs. We run gofmt -s on your code, where -s is for the "simplify" command
   test/bench/slow.go
   Line 1: warning: file is not gofmted with -s (gofmt)