### PR TITLE
Deprecated the type `ITty`. Use `ttyadapter.Tty` instead.

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ const (
 	INTR Result = iota
 )
 
+// Deprecated: Use `ttyadapter.Tty`
 type ITty = ttyadapter.Tty
 
 type Clipboard interface {

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -9,6 +9,8 @@
   - Fixed incorrect width calculation for certain emoji sequences.
     Previously, East Asian Width mode was always enabled except on Windows Terminal,
     which caused some emojis (e.g., WOMAN FACEPALMING) to be measured wider than they actually appear.
+- Deprecated the type `ITty`. Use `ttyadapter.Tty` instead. (#16)
+  This change should have been included in v1.12.0 but was missed.
 
 v1.12.2
 =======

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -7,6 +7,8 @@
     - 絵文字の幅計算の誤りを修正。
       Windows Terminal 以外では常に East Asian Width が有効になっていたため、
       文字の幾つか(例：WOMAN FACEPALMING) が実際よりも長くなっていた。
+- 型 `ITty` を非推奨（Deprecated）とした。代わりに `ttyadapter.Tty` を使用すること。(#16)
+  ※この変更は本来 v1.12.0 に含めるべきだったが、漏れていたため今回追加した。
 
 v1.12.2
 =======


### PR DESCRIPTION
## (English)

- Deprecated the type `ITty`. Use `ttyadapter.Tty` instead.
  This change should have been included in v1.12.0 but was missed.

## (Japanese)

- 型 `ITty` を非推奨（Deprecated）とした。代わりに `ttyadapter.Tty` を使用すること。
  ※この変更は本来 v1.12.0 に含めるべきだったが、漏れていたため今回追加した。