### PR TITLE
Add go doc for the type `Highlight`

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -5,6 +5,13 @@ import (
 	"unicode/utf8"
 )
 
+// Highlight defines a syntax highlighting rule.
+// Pattern can be any object that implements FindAllStringIndex(string, int) [][]int,
+// such as *regexp.Regexp.
+// The second argument to FindAllStringIndex is normally -1, but in this package
+// it is used as (-1 - cursorPosition) to pass the current cursor position to
+// non-regexp highlighters.
+// For each matched region, the escape sequence in Sequence will be applied.
 type Highlight struct {
 	Pattern  interface{ FindAllStringIndex(string, int) [][]int }
 	Sequence string


### PR DESCRIPTION
### (English)

Added an explanatory comment to Highlight to help library users understand the cursor-position handling described in [go-multiline-ny#12].

### (Japanese)
このコメントは、[go-multiline-ny#12] で問題とされた動作の前提となる仕様をライブラリユーザーが理解しやすくするために追加したものです。

[go-multiline-ny#12]: https://github.com/hymkor/go-multiline-ny/pull/12

#### Additional note for Japanese readers（日本語話者の開発者向けの補足）

シンタックスハイライト処理では、カーソル位置が分かると便利な場合があります。たとえば SKK アドオン（go-readline-skk）では、▽からカーソルまでを反転表示したり、▼からカーソルまでに下線を引いたりといった装飾に利用します。

`Highlight` の `Pattern` は `*regexp.Regexp` 互換のインターフェイスを持つため、カーソル位置を直接引き渡す仕組みは本来ありません。しかし `FindAllStringIndex` の第2引数は常に `-1` が渡されており、実質的に使われていませんでした。そこで、この値を `(-1 - cursorPosition)` として符号化し、`Pattern` 側がそれを復元することで、カーソル位置を取得できるようにしています。
