### PR TITLE
`Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor

### DIFF
--- a/gommand.go
+++ b/gommand.go
@@ -414,19 +414,37 @@ func cmdSwapChar(ctx context.Context, this *Buffer) Result {
 // CmdBackwardWord is the command that moves cursor to the top of the previous word (for M-B)
 var CmdBackwardWord = NewGoCommand("BACKWARD_WORD", cmdBackwardWord)
 
+func headOfWord(b *Buffer) int {
+	p := b.Cursor
+	for p > 0 && moji.IsSpaceMoji(b.Buffer[p-1].Moji) {
+		p--
+	}
+	for p > 0 && !moji.IsSpaceMoji(b.Buffer[p-1].Moji) {
+		p--
+	}
+	return p
+}
+
 func cmdBackwardWord(ctx context.Context, this *Buffer) Result {
-	newPos := this.Cursor
-	for newPos > 0 && moji.IsSpaceMoji(this.Buffer[newPos-1].Moji) {
-		newPos--
-	}
-	for newPos > 0 && !moji.IsSpaceMoji(this.Buffer[newPos-1].Moji) {
-		newPos--
-	}
+	newPos := headOfWord(this)
 	if newPos < this.ViewStart {
 		this.ViewStart = newPos
 	}
 	this.Cursor = newPos
 	this.repaint()
+	return CONTINUE
+}
+
+var CmdBackwardKillWord = NewGoCommand("BACKWARD_KILL_WORD", cmdBackwardKillWord)
+
+func cmdBackwardKillWord(ctx context.Context, b *Buffer) Result {
+	newPos := headOfWord(b)
+	if newPos < b.ViewStart {
+		b.ViewStart = newPos
+	}
+	b.Delete(newPos, b.Cursor-newPos)
+	b.Cursor = newPos
+	b.repaint()
 	return CONTINUE
 }
 

--- a/gommand_test.go
+++ b/gommand_test.go
@@ -112,6 +112,7 @@ func keyTest(t *testing.T, expView string, width int, typed ...string) error {
 	ss := &snapShot{}
 	prtSc := ss.String()
 	typed = append(typed, prtSc)
+	typed = append(typed, keys.Enter)
 
 	editor := &readline.Editor{
 		Tty: &auto.Pilot{

--- a/gommand_test.go
+++ b/gommand_test.go
@@ -172,3 +172,9 @@ func TestCmdInterrupt(t *testing.T) {
 		t.Fatalf("expect CtrlC, but %v", result)
 	}
 }
+
+func TestCmdBackwardKillWord(t *testing.T) {
+	keyTest(t, "[foo   |]", 80, "foo   bar   baz", keys.AltBackspace, keys.AltBackspace)
+	keyTest(t, "[foo   |baz]", 80, "foo   bar   baz", keys.AltB, keys.AltBackspace)
+	keyTest(t, "[foo   |  baz]", 80, "foo   bar   baz", keys.AltB, keys.Left, keys.Left, keys.AltBackspace)
+}

--- a/keymap.go
+++ b/keymap.go
@@ -55,6 +55,8 @@ var GlobalKeyMap = &KeyMap{
 
 		keys.Escape + keys.Left:  CmdBackwardWord,
 		keys.Escape + keys.Right: CmdForwardWord,
+		keys.AltBackspace:        CmdBackwardKillWord,
+		keys.Escape + keys.CtrlW: CmdBackwardKillWord,
 	},
 }
 

--- a/keys/code.go
+++ b/keys/code.go
@@ -43,7 +43,7 @@ const (
 	Escape        = "\x1B"
 	AltA          = "\x1Ba"
 	AltB          = "\x1Bb"
-	ALTBackspace  = "\x1B\b"
+	AltBackspace  = "\x1B\b"
 	AltC          = "\x1Bc"
 	AltD          = "\x1Bd"
 	AltE          = "\x1Be"

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -8,6 +8,7 @@ Release notes (English)
 - `Esc`+`Left`  now behaves the same as `Esc`+`b` or `Alt`+`b`.(#22)
 - `Esc`+`Right` now behaves the same as `Esc`+`f` or `Alt`+`f`.(#22)
 - Changed the behavior of `Alt` + `f`, which previously moved the cursor to the beginning of the next word, to match GNU readline: it now moves to the end of the current or next word. (#23)
+- `Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor. (#24)
 
 v1.13.0
 -------

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -8,6 +8,7 @@ Release notes (Japanese)
 - `Esc`+`Left`  を `Esc`+`b`, `Alt`+`b` と等価にした。(#22)
 - `Esc`+`Right` を `Esc`+`f`, `Alt`+`f` と等価にした。(#22)
 - これまで次の単語の先頭への移動だった Alt + f の挙動を本家の readline に合わせ、現在または次の単語の末尾へ移動するように修正した。 (#23)
+- `Alt`/`Esc`+`Backspace`, `ESC`+`Ctrl`+`w` で、カーソル左の単語を削除するようにした。 (#24)
 
 v1.13.0
 -------


### PR DESCRIPTION
(English)
- `Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor

(Japanese)
- `Alt`/`Esc`+`Backspace`, `ESC`+`Ctrl`+`w` で、カーソル左の単語を削除するようにした。