### PR TITLE
Rename release note files to CHANGELOG.md and CHANGELOG_ja.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+- Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md (#29)
+
 v1.14.1
 -------
 Jan 29, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-Release notes (English)
+Changelog (English)
 =======================
-( **English** / [Japanese](release_note_ja.md) )
+( **English** / [Japanese](CHANGELOG_ja.md) )
 
 v1.14.1
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -1,6 +1,6 @@
-Release notes (Japanese)
+Changelog (Japanese)
 ========================
-( [English](release_note_en.md) / **Japanese** )
+( [English](CHANGELOG.md) / **Japanese** )
 
 v1.14.1
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,8 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+- リリースノートのファイルを CHANGELOG.md とCHANGELOG\_ja.md へリネーム (#29)
+
 v1.14.1
 -------
 Jan 29, 2026

--- a/README.md
+++ b/README.md
@@ -278,11 +278,11 @@ func main() {
 
 This feature enables automated testing of readline behaviors—such as cursor movement, text editing, and key bindings - without requiring a real terminal.
 
-Release notes
+Changelog
 -------------
 
-- [Release notes (English)](release_note_en.md)
-- [Release notes (Japanese)](release_note_ja.md)
+- [Changelog (English)](CHANGELOG.md)
+- [Changelog (Japanese)](CHANGELOG_ja.md)
 
 License
 -------


### PR DESCRIPTION
(English)
- Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md

(Japanese)
- リリースノートのファイルを CHANGELOG.md とCHANGELOG\_ja.md へリネーム