### PR TITLE
Restore `Editor.PredictColor` and `Editor.Predictor` to maintain backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+- Fix regression in `Editor` initialization (v1.14.2) (#33):
+  - `PredictColor` and `Predictor` fields have been restored for backward compatibility
+
 v1.14.2
 -------
 Apr 9, 2026

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,9 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+- `Editor` 構造体で発生した非互換性の修正 (v1.14.2) (#33):
+  - フィールド `PredictColor` と `Predictor` を互換性のために復活
+
 v1.14.2
 -------
 Apr 9, 2026

--- a/main.go
+++ b/main.go
@@ -71,7 +71,10 @@ type Editor struct {
 	ResetColor   string
 	DefaultColor string
 
+	PredictColor [2]string            // for compatibility
+	Predictor    func(*Buffer) string // for compatibility
 	predict
+
 	OnAfterRender func(B *Buffer, availWidth int)
 	AfterCommand  func(*Buffer) // An experimental field
 	// Deprecated: use Highlight
@@ -173,7 +176,7 @@ func (editor *Editor) Init() {
 	if editor.Clipboard == nil {
 		editor.Clipboard = &defaultClipboard{}
 	}
-	editor.predict.install(editor)
+	editor.predict.install(editor, editor.PredictColor, editor.Predictor)
 }
 
 // ReadLine calls LineEditor

--- a/predict.go
+++ b/predict.go
@@ -12,9 +12,9 @@ import (
 var PredictColorBlueItalic = [...]string{"\x1B[3;22;34m", "\x1B[23;39m"}
 
 type predict struct {
-	suffix       []Moji
-	PredictColor [2]string
-	Predictor    func(*Buffer) string
+	suffix    []Moji
+	colors    [2]string
+	predictor func(*Buffer) string
 }
 
 func predictByHistory(B *Buffer) string {
@@ -29,20 +29,20 @@ func predictByHistory(B *Buffer) string {
 }
 
 func (P *predict) onAfterRenderPredict(B *Buffer, availWidth int) {
-	if P.PredictColor[0] == "" || B.Cursor != len(B.Buffer) {
+	if P.colors[0] == "" || B.Cursor != len(B.Buffer) {
 		return
 	}
 	if len(B.Buffer) <= 0 {
 		P.suffix = nil
-	} else if P.Predictor != nil {
-		P.suffix = moji.StringToMoji(P.Predictor(B))
+	} else if P.predictor != nil {
+		P.suffix = moji.StringToMoji(P.predictor(B))
 	} else {
 		P.suffix = moji.StringToMoji(predictByHistory(B))
 	}
 	if len(P.suffix) <= len(B.Buffer) {
 		return
 	}
-	io.WriteString(B.Out, B.PredictColor[0]) // "\x1B[3;22;39m"
+	io.WriteString(B.Out, B.colors[0]) // "\x1B[3;22;39m"
 	sfx := P.suffix
 	for i := len(B.Buffer); i < len(sfx); i++ {
 		c := sfx[i]
@@ -52,7 +52,7 @@ func (P *predict) onAfterRenderPredict(B *Buffer, availWidth int) {
 		}
 		c.PrintTo(B.Out)
 	}
-	io.WriteString(B.Out, P.PredictColor[1]) // "\x1B[23m"
+	io.WriteString(B.Out, P.colors[1]) // "\x1B[23m"
 }
 
 func (P *predict) accept(b *Buffer) {
@@ -66,11 +66,14 @@ func (P *predict) accept(b *Buffer) {
 	b.ReplaceAndRepaint(0, s.String())
 }
 
-func (p *predict) install(editor *Editor) {
+func (P *predict) install(editor *Editor, colors [2]string, f func(*Buffer) string) {
 	if editor.OnAfterRender != nil {
 		return
 	}
-	editor.OnAfterRender = editor.predict.onAfterRenderPredict
+	P.colors = colors
+	P.predictor = f
+
+	editor.OnAfterRender = P.onAfterRenderPredict
 	editor.KeyMap.BindKey(keys.Right, CmdForwardCharOrAcceptPredict)
 	editor.KeyMap.BindKey(keys.CtrlF, CmdForwardCharOrAcceptPredict)
 }
@@ -78,7 +81,7 @@ func (p *predict) install(editor *Editor) {
 var CmdAcceptPredict = NewGoCommand("ACCEPT_PREDICT", cmdAcceptPredict)
 
 func cmdAcceptPredict(ctx context.Context, b *Buffer) Result {
-	b.accept(b)
+	b.predict.accept(b)
 	return CONTINUE
 }
 
@@ -88,6 +91,6 @@ func cmdForwardCharOrAcceptPredict(ctx context.Context, b *Buffer) Result {
 	if b.Cursor < len(b.Buffer) {
 		return cmdForwardChar(ctx, b)
 	}
-	b.accept(b)
+	b.predict.accept(b)
 	return CONTINUE
 }


### PR DESCRIPTION
## (English)
- Fix regression in `Editor` initialization (v1.14.2) :
  - `PredictColor` and `Predictor` fields have been restored for backward compatibility

## (Japenese)
- `Editor` 構造体で発生した非互換性の修正（v1.14.2）
  - フィールド `PredictColor` と `Predictor` を互換性のために復活