### PR TITLE
Add `REPAINT_LINE` command (`CmdRepaintLine` Object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+### Bug fixes
+
 - Fix regression in `Editor` initialization (v1.14.2) (#33):
   - `PredictColor` and `Predictor` fields have been restored for backward compatibility
+
+### New features
+
+- Add `REPAINT_LINE` command (`CmdRepaintLine` Object) (#34):
+  - Redraws the current line without clearing the screen or adding a newline
 
 v1.14.2
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,8 +2,15 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+### 不具合修正
+
 - `Editor` 構造体で発生した非互換性の修正 (v1.14.2) (#33):
   - フィールド `PredictColor` と `Predictor` を互換性のために復活
+
+### 仕様追加
+
+- `REPAINT_LINE` コマンド (`CmdRepaintLine` オブジェクト) を追加 (#34)
+  - 画面のクリアや改行をせずに現在行を再描画
 
 v1.14.2
 -------

--- a/gommand.go
+++ b/gommand.go
@@ -303,6 +303,13 @@ func cmdRepaintOnNewline(ctx context.Context, this *Buffer) Result {
 	return CONTINUE
 }
 
+var CmdRepaintLine = NewGoCommand("REPAINT_LINE", cmdRepaintLine)
+
+func cmdRepaintLine(ctx context.Context, this *Buffer) Result {
+	this.RepaintLastLine()
+	return CONTINUE
+}
+
 // CmdQuotedInsert is the command that inserts the next typed character itself even if it is a control-character (for Ctrl-V or Ctrl-Q)
 var CmdQuotedInsert = NewGoCommand("QUOTED_INSERT", cmdQuotedInsert)
 

--- a/test/repaint/main.go
+++ b/test/repaint/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mattn/go-colorable"
+
+	"github.com/nyaosorg/go-readline-ny"
+	"github.com/nyaosorg/go-readline-ny/keys"
+)
+
+func mains() error {
+	colorable.EnableColorsStdout(nil)
+
+	var w io.Writer = colorable.NewColorableStdout()
+
+	editor := readline.Editor{
+		PromptWriter: func(w io.Writer) (int, error) {
+			return io.WriteString(w, "String: \"")
+		},
+		OnAfterRender: func(B *readline.Buffer, availWidth int) {
+			if availWidth >= 1 {
+				B.Out.Write([]byte{'"', '\b'})
+			}
+		},
+		// Coloring: &coloring.VimBatch{},
+		Writer: w,
+	}
+	editor.BindKey(keys.CtrlL, readline.CmdRepaintLine)
+	editor.BindKey(keys.CtrlBackslash, &readline.GoCommand{
+		Name: "noise command",
+		Func: func(_ context.Context, b *readline.Buffer) readline.Result {
+			io.WriteString(b.Out, "noise noise noise noise")
+			return readline.CONTINUE
+		},
+	})
+	text, err := editor.ReadLine(context.Background())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("TEXT=%s\n", text)
+	return nil
+}
+
+func main() {
+	if err := mains(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
### (English)

- Add `REPAINT_LINE` command (`CmdRepaintLine` Object):
  - Redraws the current line without clearing the screen or adding a newline

### (Japanese)

- `REPAINT_LINE` コマンド (`CmdRepaintLine` オブジェクト) を追加
  - 画面のクリアや改行をせずに現在行を再描画