### PR TITLE
Fix `OnAfterRender` output being erased due to render order issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog (English)
 
 - Fix regression in `Editor` initialization (v1.14.2) (#33):
   - `PredictColor` and `Predictor` fields have been restored for backward compatibility
+- Fix `OnAfterRender` output being erased due to render order issues (#35)
+  - Affected commands include `END_OF_LINE`, `KILL_LINE`, and `FORWARD_CHAR`
 
 ### New features
 

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -6,6 +6,8 @@ Changelog (Japanese)
 
 - `Editor` 構造体で発生した非互換性の修正 (v1.14.2) (#33):
   - フィールド `PredictColor` と `Predictor` を互換性のために復活
+- 描画順の問題で、`OnAfterRender` の出力が消えてしまう不具合を修正 (#35)
+  - 影響コマンド: `END_OF_LINE`, `KILL_LINE`, `FORWARD_CHAR`
 
 ### 仕様追加
 

--- a/buffer.go
+++ b/buffer.go
@@ -53,24 +53,52 @@ func (B *Buffer) ViewWidth() WidthT {
 	return WidthT(B.termWidth) - WidthT(B.topColumn) - ScrollMargin
 }
 
-func (B *Buffer) getView() (_Range, WidthT) {
+type viewResult struct {
+	b     *Buffer
+	view  _Range
+	after _Range
+	width WidthT
+}
+
+func (v *viewResult) All() _Range       { return v.view }
+func (v *viewResult) After() _Range     { return v.after }
+func (v *viewResult) DrawWidth() WidthT { return v.width }
+
+func (v *viewResult) availWidth() WidthT { return v.b.ViewWidth() - v.width }
+
+func (B *Buffer) getView() *viewResult {
 	view := B.Buffer[B.ViewStart:]
 	width := B.ViewWidth()
 	w := WidthT(0)
 	for i, c := range view {
-		_w := w
-		w += c.Moji.Width()
-		if w >= width {
-			return view[:i], _w
+		newW := w + c.Moji.Width()
+		if newW > width {
+			return &viewResult{
+				b:     B,
+				view:  view[:i],
+				after: view[i:],
+				width: w,
+			}
 		}
+		w = newW
 	}
-	return view, w
+	return &viewResult{
+		b:     B,
+		view:  view,
+		after: view[len(view):],
+		width: w,
+	}
 }
 
-func (B *Buffer) getView2() (all _Range, before _Range, w WidthT) {
-	v, w := B.getView()
-	x := B.Cursor - B.ViewStart
-	return v, v[:x], w
+func (v *viewResult) LeftOfCursor() _Range {
+	x := v.b.Cursor - v.b.ViewStart
+	return v.view[:x]
+}
+
+func (B *Buffer) callOnAfterRender(w WidthT) {
+	if B.Editor.OnAfterRender != nil {
+		B.Editor.OnAfterRender(B, int(w+ScrollMargin))
+	}
 }
 
 func (B *Buffer) insert(csrPos int, insStr []Cell) {

--- a/gommand.go
+++ b/gommand.go
@@ -233,6 +233,8 @@ func cmdKillLine(ctx context.Context, this *Buffer) Result {
 	this.Clipboard.Write(this.SubString(this.Cursor, len(this.Buffer)))
 
 	this.eraseline()
+	this.callOnAfterRender(this.getView().availWidth())
+
 	u := &_Undo{
 		pos:  this.Cursor,
 		text: cell2string(this.Buffer[this.Cursor:]),

--- a/gommand.go
+++ b/gommand.go
@@ -138,6 +138,9 @@ func cmdForwardChar(ctx context.Context, this *Buffer) Result {
 		this.ViewStart++
 		this.puts(this.Buffer[this.ViewStart : this.Cursor+1])
 		this.eraseline()
+		if this.Cursor+1 >= len(this.Buffer) {
+			this.callOnAfterRender(this.getView().availWidth())
+		}
 	}
 	this.Cursor++
 	return CONTINUE

--- a/gommand.go
+++ b/gommand.go
@@ -89,28 +89,32 @@ var CmdEndOfLine = NewGoCommand("END_OF_LINE", cmdEndOfLine)
 
 func cmdEndOfLine(ctx context.Context, this *Buffer) Result {
 	allength := this.GetWidthBetween(this.ViewStart, len(this.Buffer))
+
+	var w WidthT
 	if allength <= this.ViewWidth() {
 		this.puts(this.Buffer[this.Cursor:])
 		this.Cursor = len(this.Buffer)
+		w = this.ViewWidth() - allength
 	} else {
 		this.GotoHead()
 		this.ViewStart = len(this.Buffer) - 1
-		w := this.Buffer[this.ViewStart].Moji.Width()
+		w = this.Buffer[this.ViewStart].Moji.Width()
 		for {
 			if this.ViewStart <= 0 {
 				break
 			}
-			_w := w + this.Buffer[this.ViewStart-1].Moji.Width()
-			if _w > this.ViewWidth() {
+			newW := w + this.Buffer[this.ViewStart-1].Moji.Width()
+			if newW > this.ViewWidth() {
 				break
 			}
-			w = _w
+			w = newW
 			this.ViewStart--
 		}
 		this.puts(this.Buffer[this.ViewStart:])
 		this.Cursor = len(this.Buffer)
 	}
 	this.eraseline()
+	this.callOnAfterRender(w)
 	return CONTINUE
 }
 

--- a/isearch.go
+++ b/isearch.go
@@ -82,11 +82,11 @@ func cmdISearchBackward(ctx context.Context, this *Buffer) Result {
 			this.ReplaceAndRepaint(0, foundStr)
 			return CONTINUE
 		case "\x03", "\x07", "\x1B":
-			all, left, _ := this.getView2()
-			this.puts(all)
+			v := this.getView()
+			this.puts(v.All())
 			this.eraseline()
 			this.GotoHead()
-			this.puts(left)
+			this.puts(v.LeftOfCursor())
 			return CONTINUE
 		case "\x12":
 			for i := lastFoundPos - 1; ; i-- {

--- a/repaints.go
+++ b/repaints.go
@@ -75,16 +75,16 @@ func (B *Buffer) GotoHead() {
 }
 
 func (B *Buffer) repaint() {
-	all, left, w := B.getView2()
+	v := B.getView()
 	B.GotoHead()
 	puts := B.newPrinter()
-	puts(all)
-	if B.Editor.OnAfterRender != nil {
-		B.Editor.OnAfterRender(B, int(B.ViewWidth()-w))
-	}
+	puts(v.All())
 	B.eraseline()
+	if len(v.After()) <= 0 {
+		B.callOnAfterRender(B.ViewWidth() - v.DrawWidth())
+	}
 	B.GotoHead()
-	puts(left)
+	puts(v.LeftOfCursor())
 }
 
 // DrawFromHead draw all text in viewarea and


### PR DESCRIPTION
- Fix `OnAfterRender` output being erased due to render order issues
  - Affected commands include `END_OF_LINE`, `KILL_LINE`, and `FORWARD_CHAR`
&nbsp;
- 描画順の問題で、`OnAfterRender` の出力が消えてしまう不具合を修正
  - 影響コマンド: `END_OF_LINE`, `KILL_LINE`, `FORWARD_CHAR`
