### PR TITLE
Pin go-tty to v0.0.7 for stable blocking behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+- Pin go-tty to v0.0.7 for stable blocking behavior (#38)
+  - Update github.com/mattn/go-tty to v0.0.7
+  - Update github.com/nyaosorg/go-ttyadapter to v0.3.0
+
 v1.15.0
 -------
 Apr 27, 2026

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,10 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+- キー入力の待ち動作に変更があるようなので、go-tty を v0.0.7 へ固定 (#38)
+  - github.com/mattn/go-tty を v0.0.7 へ更新
+  - github.com/nyaosorg/go-ttyadapter を v0.3.0 へ更新
+
 v1.15.0
 -------
 Apr 27, 2026

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/nyaosorg/go-box/v3 v3.1.1
-	github.com/nyaosorg/go-ttyadapter v0.6.0
+	github.com/nyaosorg/go-ttyadapter v0.3.0
 )
 
 require (
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/mattn/go-tty/v2 v2.0.0 // indirect
+	github.com/mattn/go-tty v0.0.7 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,12 +8,12 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/mattn/go-tty/v2 v2.0.0 h1:AgXDfbKcENaiQbjdQ+o2ZusbtiaOhK1ArFD75d5U6qk=
-github.com/mattn/go-tty/v2 v2.0.0/go.mod h1:azVwsnH46TUJRQPRp/IrUT+8nRkkvjvkESJJxAA4Y48=
+github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
+github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
 github.com/nyaosorg/go-box/v3 v3.1.1 h1:iTWE0MOTlD52yEySfhdN6nonX7Uagkn985xQZM6sCyI=
 github.com/nyaosorg/go-box/v3 v3.1.1/go.mod h1:kuRLL+x9n7kqIAiSZRXgNxP+HJVelsCKplo2TQSnWIo=
-github.com/nyaosorg/go-ttyadapter v0.6.0 h1:9/IAk2YKloIyz571pUyW5pzZShWrjxaoZnAKVLqxvdk=
-github.com/nyaosorg/go-ttyadapter v0.6.0/go.mod h1:WxypDPeSfM0+z2yG7q3wVhE/LR4pVXjyGkEk9cA/T7A=
+github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=
+github.com/nyaosorg/go-ttyadapter v0.3.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=


### PR DESCRIPTION
Pin go-tty to v0.0.7 to avoid potential non-blocking behavior changes

Recent versions of go-tty appear to introduce changes in read behavior, possibly related to non-blocking mode (e.g. via SetNonblock in raw mode).

While no issue has been observed in this environment, there are reports that ReadRune may return EAGAIN under certain conditions (e.g. interactive shells / pty), which differs from the expected blocking behavior.

This can be revisited once the intended behavior of go-tty is clarified.