### PR TITLE
Bump to v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+v1.15.1
+-------
+May 3, 2026
+
 - Pin go-tty to v0.0.7 for stable blocking behavior
   - Update github.com/mattn/go-tty to v0.0.7 (#38)
 - Update `go-ttyadapter` to v0.6.2: Switched the default TTY backend via `go-ttyadapter/fav` as follows: (#39)

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,10 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+v1.15.1
+-------
+May 3, 2026
+
 - キー入力の待ち動作に変更があるようなので、go-tty を v0.0.7 へ固定
   - github.com/mattn/go-tty を v0.0.7 へ更新 (#38)
 - github.com/nyaosorg/go-ttyadapter を v0.6.2 へ更新し、go-ttyadapter/fav の経由でデフォルトの端末入力を次のとおりとした (#39)


### PR DESCRIPTION
[Release v1.15.1 · nyaosorg/go-readline-ny](https://github.com/nyaosorg/go-readline-ny/releases/tag/v1.15.1)